### PR TITLE
修复long->int数据溢出问题

### DIFF
--- a/src/main/java/io/taraxacum/finaltech/setup/SetupUtil.java
+++ b/src/main/java/io/taraxacum/finaltech/setup/SetupUtil.java
@@ -475,7 +475,7 @@ public final class SetupUtil {
                 FinalTechItems.ENTROPY,
                 FinalTechItems.ENTROPY_CONSTRUCTOR,
                 FinalTechItems.ENTROPY_SEED);
-        ResearchUtil.setResearches(FinalTech.getLanguageManager(), "BOX", ((int)FinalTech.getSeed()) % 20, false,
+        ResearchUtil.setResearches(FinalTech.getLanguageManager(), "BOX", (((int)FinalTech.getSeed()) % 20) &0x7fffffff, false,
                 FinalTechItems.BOX,
                 FinalTechItems.SHINE);
         ResearchUtil.setResearches(FinalTech.getLanguageManager(), "ANNULAR", (int)Math.pow(ConstantTableUtil.ITEM_COPY_CARD_AMOUNT, 0.25), true,


### PR DESCRIPTION
该更改基于C语法，未进行测试，明白意思就行。
已确定更改前会生成负数，导致Research.setCost抛出异常。
`java.lang.IllegalArgumentException: Research cost must be zero or greater!
	at io.github.thebusybiscuit.slimefun4.api.researches.Research.setCost(Research.java:149) ~[?:?]
	at io.github.thebusybiscuit.slimefun4.api.researches.Research.register(Research.java:302) ~[?:?]
	at io.taraxacum.libs.slimefun.util.ResearchUtil.setResearches(ResearchUtil.java:47) ~[?:?]
	at io.taraxacum.finaltech.setup.SetupUtil.init(SetupUtil.java:478) ~[?:?]
	at io.taraxacum.finaltech.FinalTech.onEnable(FinalTech.java:172) ~[?:?]`